### PR TITLE
セーブポイントの作成、シーン切り替え時のプレイヤー吹っ飛び抑制

### DIFF
--- a/Balance/Assets/Prefabs/Enemy/EncountArea.prefab
+++ b/Balance/Assets/Prefabs/Enemy/EncountArea.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 1011290209381604344}
   - component: {fileID: 1011290209381604351}
   - component: {fileID: 2986039606335571844}
+  - component: {fileID: 7056358312725247127}
   m_Layer: 0
   m_Name: EncountArea
   m_TagString: EncountArea
@@ -31,7 +32,8 @@ Transform:
   m_LocalPosition: {x: 125.5, y: 30.5, z: 209.7}
   m_LocalScale: {x: 44.46287, y: 44.46287, z: 44.46287}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4104791228974969546}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -110,4 +112,47 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 497f9c3f7788e2744958379fb9eaea8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  isEncount: 0
+--- !u!114 &7056358312725247127
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1011290209381604350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: da5613e944d34c6facb0684ef186ef72, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  savePoint: {fileID: 8148575482117142682}
+--- !u!1 &8148575482117142682
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4104791228974969546}
+  m_Layer: 0
+  m_Name: SavePoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4104791228974969546
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8148575482117142682}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2.101}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1011290209381604346}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Balance/Assets/Prefabs/Enemy/EncountArea.prefab
+++ b/Balance/Assets/Prefabs/Enemy/EncountArea.prefab
@@ -13,7 +13,6 @@ GameObject:
   - component: {fileID: 1011290209381604344}
   - component: {fileID: 1011290209381604351}
   - component: {fileID: 2986039606335571844}
-  - component: {fileID: 7056358312725247127}
   m_Layer: 0
   m_Name: EncountArea
   m_TagString: EncountArea
@@ -32,8 +31,7 @@ Transform:
   m_LocalPosition: {x: 125.5, y: 30.5, z: 209.7}
   m_LocalScale: {x: 44.46287, y: 44.46287, z: 44.46287}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4104791228974969546}
+  m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -112,47 +110,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 497f9c3f7788e2744958379fb9eaea8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &7056358312725247127
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1011290209381604350}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: da5613e944d34c6facb0684ef186ef72, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  savePoint: {fileID: 8148575482117142682}
---- !u!1 &8148575482117142682
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4104791228974969546}
-  m_Layer: 0
-  m_Name: SavePoint
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4104791228974969546
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8148575482117142682}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2.101}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1011290209381604346}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  isEncount: 0

--- a/Balance/Assets/Scripts/Player/PlayerController.cs
+++ b/Balance/Assets/Scripts/Player/PlayerController.cs
@@ -183,7 +183,7 @@ public class PlayerController : MonoBehaviour
             DashSwitch();
         }
  
-        if (isChanged)
+        if (isChanged && m_RB.isKinematic == false)
         {
             movementAmount = m_RB.position + m_stageMovement.MovementAmount;
             m_RB.MovePosition(movementAmount);

--- a/Balance/Assets/Scripts/Player/PlayerManager.cs
+++ b/Balance/Assets/Scripts/Player/PlayerManager.cs
@@ -56,7 +56,9 @@ public class PlayerManager : MonoBehaviour
             return;
         }
         GameManager.instance.SavePlayerInstance(gameObject);
-       
+
+        m_RB = GetComponent<Rigidbody>();
+
     }
 
     private ThrowawayMethod method;
@@ -209,5 +211,16 @@ public class PlayerManager : MonoBehaviour
         _playerController.enabled = true;
         transform.rotation = quaternion.identity;
     }
-  
+
+    private Rigidbody m_RB;
+
+    public void LockPos()
+    {
+        GameManager.instance.ResetRBVelocity(m_RB);
+        m_RB.isKinematic = true;
+        Debug.Log("call Lock");
+        //GameManager.instance.ResetRBVelocity(m_RB);
+    }
+ 
+    public void UnLockPos() => m_RB.isKinematic = false;
 }

--- a/Balance/Assets/Scripts/System/GameManager.cs
+++ b/Balance/Assets/Scripts/System/GameManager.cs
@@ -214,7 +214,10 @@ public class GameManager : MonoBehaviour
     // ここで呼んでるコルーチンを
     private void OnStateChange()
     {
-        Debug.Log("stateChange " + m_beforeState + " to " + m_currentState);
+       // Debug.Log("stateChange " + m_beforeState + " to " + m_currentState);
+       
+        instance.PlayerLock();
+       
         if (m_beforeState == GameState.EnemyBattle &&
             m_currentState == GameState.Search)   // 戦闘->探索
         {
@@ -224,13 +227,13 @@ public class GameManager : MonoBehaviour
         else if (m_beforeState == GameState.Search &&
                  m_currentState == GameState.EnemyBattle) // 探索->戦闘
         {
-            SaveAircraftPos(m_aircraftInstance.transform.position);
+          //  SaveAircraftPos(m_aircraftInstance.transform.position);
             AircraftMoveSwitch(false);
         }
         else if (m_beforeState == GameState.Search &&
                  m_currentState == GameState.GameOver) // 探索->ゲームオーバー
         {
-            SaveAircraftPos(m_aircraftInstance.transform.position);
+          //  SaveAircraftPos(m_aircraftInstance.transform.position);
             AircraftMoveSwitch(false);
         }
         /*
@@ -261,7 +264,7 @@ public class GameManager : MonoBehaviour
     /// <summary>
     /// 自機の場所保存 探索->戦闘に切り替わったとき呼びたい
     /// </summary>
-    private void SaveAircraftPos(Vector3 position)
+    public void SaveAircraftPos(Vector3 position)
     {
         m_aircraftPos = position;
     }
@@ -406,6 +409,35 @@ public class GameManager : MonoBehaviour
             }
         }
     }
+
+    public void PlayerLock()
+    {
+        foreach (GameObject player in playerInstances)
+        {
+            if (player == null)
+            {
+                Debug.Log("PlayerInstance is null");
+                return;
+            }
+
+            player.GetComponent<PlayerManager>().LockPos();
+        }
+    }
+    
+    public void PlayerUnLock()
+    {
+        foreach (GameObject player in playerInstances)
+        {
+            if (player == null)
+            {
+                Debug.Log("PlayerInstance is null");
+                return;
+            }
+
+            player.GetComponent<PlayerManager>().UnLockPos();
+
+        }
+    }
     /// <summary>
     /// 戦闘->探索に戻った時の処理
     /// </summary>
@@ -489,7 +521,8 @@ public class GameManager : MonoBehaviour
         {
             Debug.LogAssertion("m_aircraftInstance is null!");
             yield break;
-        }
+        } 
+        
         m_aircraftInstance.transform.position = m_aircraftPos;
         
         SetPlayerPos();

--- a/Balance/Assets/Scripts/System/SavePoint.cs
+++ b/Balance/Assets/Scripts/System/SavePoint.cs
@@ -1,0 +1,18 @@
+﻿using UnityEngine;
+
+namespace System
+{
+    public class SavePoint : MonoBehaviour
+    {
+        [SerializeField] private GameObject savePoint;
+        private void Save()
+        {
+            GameManager.instance.SaveAircraftPos(savePoint.transform.position);
+        }
+
+        private void OnTriggerEnter(Collider other)
+        {
+            Save();
+        }
+    }
+}

--- a/Balance/Assets/Scripts/System/SavePoint.cs.meta
+++ b/Balance/Assets/Scripts/System/SavePoint.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: da5613e944d34c6facb0684ef186ef72
+timeCreated: 1736455772

--- a/Balance/Assets/Scripts/System/SceneTransitionHandler.cs
+++ b/Balance/Assets/Scripts/System/SceneTransitionHandler.cs
@@ -43,6 +43,8 @@ namespace System
                 GameManager.instance.RestartAtSavePoint(true);
                 Debug.Log("Restart 1 ");
             }
+            
+            
 
             m_beforeSceneName = scene.name;
         }
@@ -78,7 +80,7 @@ namespace System
               //  GameManager.instance.Back2Search();
                 GameManager.instance.CurrentState = GameState.Search;
             }
-
+            GameManager.instance.PlayerUnLock();
             m_beforeSceneName = null;
 
         }


### PR DESCRIPTION
## やった事
<!-- このプルリクエストにて何をしたのか？ -->
- セーブポイントの作成
- シーン切り替え時にプレイヤーが吹っ飛ばないように固定

### Related Issue
<!-- 番号を#のあと指定するとissue閉じれるよ -->
close #~~

### 動作確認
<!--
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->
- ためしにエンカウントエリアにセーブポイントつけてちゃんと動いた
- プレイヤーの固定とその解除も動作確認済み

### レビューしてほしいこと
[ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報など -->
-