### PR TITLE
アイテムやエンカウントの進捗状況保持と反映＋いろいろバグ修正と調整

### DIFF
--- a/Balance/.idea/.idea.Balance/.idea/encodings.xml
+++ b/Balance/.idea/.idea.Balance/.idea/encodings.xml
@@ -4,6 +4,7 @@
     <file url="file://$PROJECT_DIR$/Assets/Scripts/Enemy/Enemy.cs" charset="windows-31j" />
     <file url="file://$PROJECT_DIR$/Assets/Scripts/Enemy/EnemySpawnScript.cs" charset="windows-31j" />
     <file url="file://$PROJECT_DIR$/Assets/Scripts/System/Dialogue/DisplayDialogue.cs" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/Assets/Scripts/System/FieldItems/FieldItemsManager.cs" charset="UTF-8" />
     <file url="PROJECT" charset="windows-31j" />
   </component>
 </project>

--- a/Balance/Assets/Effect/twinkle/Twinkle.prefab
+++ b/Balance/Assets/Effect/twinkle/Twinkle.prefab
@@ -54,7 +54,7 @@ VisualEffect:
       - m_Value: 50
         m_Name: ParticleSize
         m_Overridden: 1
-      - m_Value: 7
+      - m_Value: 4.07
         m_Name: PositionRadius
         m_Overridden: 1
     m_Vector2f:

--- a/Balance/Assets/Import/UI/InGame/Life/heart03 (1).png
+++ b/Balance/Assets/Import/UI/InGame/Life/heart03 (1).png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fd8dd9c1cb8f7ff9df3d6f94ecafe6ebaa8730f94f134cfb2b3fb3dc1a1bd9a
+size 62940

--- a/Balance/Assets/Import/UI/InGame/Life/heart03 (1).png.meta
+++ b/Balance/Assets/Import/UI/InGame/Life/heart03 (1).png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: 8d61d3c6d85b76a4a951c06510a6d7fa
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Balance/Assets/Prefabs/Enemy/Don`tUse/EncountArea.prefab
+++ b/Balance/Assets/Prefabs/Enemy/Don`tUse/EncountArea.prefab
@@ -141,7 +141,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5186034774702906565}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.044, z: -2.958}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Balance/Assets/Prefabs/Parts/Battery.prefab
+++ b/Balance/Assets/Prefabs/Parts/Battery.prefab
@@ -451,6 +451,7 @@ Transform:
   - {fileID: 8608070940740031581}
   - {fileID: 540573960230661128}
   - {fileID: 5066630507948603126}
+  - {fileID: 8470884667241361233}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -581,3 +582,93 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1001 &777890963376673658
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6577118669028239271}
+    m_Modifications:
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.04614964
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.04614964
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.04614964
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.015449
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.10049
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.45113
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837230, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_Name
+      value: Twinkle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 496add8e97f96a74187a018ceae8b204, type: 3}
+--- !u!4 &8470884667241361233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+    type: 3}
+  m_PrefabInstance: {fileID: 777890963376673658}
+  m_PrefabAsset: {fileID: 0}

--- a/Balance/Assets/Prefabs/Parts/antena.prefab
+++ b/Balance/Assets/Prefabs/Parts/antena.prefab
@@ -33,6 +33,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8087446127124824117}
+  - {fileID: 806874414284645109}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -143,3 +144,93 @@ Transform:
   m_Father: {fileID: 3952238111704256593}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &8392360108930981598
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 3952238111704256593}
+    m_Modifications:
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.01
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837230, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_Name
+      value: Twinkle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 496add8e97f96a74187a018ceae8b204, type: 3}
+--- !u!4 &806874414284645109 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+    type: 3}
+  m_PrefabInstance: {fileID: 8392360108930981598}
+  m_PrefabAsset: {fileID: 0}

--- a/Balance/Assets/Prefabs/Parts/warp.prefab
+++ b/Balance/Assets/Prefabs/Parts/warp.prefab
@@ -31,7 +31,8 @@ Transform:
   m_LocalPosition: {x: 0.000000036345924, y: 0.000000028237451, z: 0.07593027}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3256334467780495906}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -111,3 +112,93 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   savePoint: {fileID: 0}
+--- !u!1001 &5941916961848833545
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 9215904718139877549}
+    m_Modifications:
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.051386
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.051386
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.051386
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.028334
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.03324
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.003564
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9170805540575837230, guid: 496add8e97f96a74187a018ceae8b204,
+        type: 3}
+      propertyPath: m_Name
+      value: Twinkle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 496add8e97f96a74187a018ceae8b204, type: 3}
+--- !u!4 &3256334467780495906 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9170805540575837227, guid: 496add8e97f96a74187a018ceae8b204,
+    type: 3}
+  m_PrefabInstance: {fileID: 5941916961848833545}
+  m_PrefabAsset: {fileID: 0}

--- a/Balance/Assets/Prefabs/System/FiledItemManager.prefab
+++ b/Balance/Assets/Prefabs/System/FiledItemManager.prefab
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7399610949179236820
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1219654002456651467}
+  - component: {fileID: 7809414863400933574}
+  m_Layer: 0
+  m_Name: FiledItemManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1219654002456651467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7399610949179236820}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7809414863400933574
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7399610949179236820}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b8a1a1cf5704ceaba078b3d3973abfd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  acquired: 

--- a/Balance/Assets/Prefabs/System/FiledItemManager.prefab.meta
+++ b/Balance/Assets/Prefabs/System/FiledItemManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 876b6f511a8c8fd4f83c589664bc9d5e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Balance/Assets/Prefabs/System/SoundManager.prefab
+++ b/Balance/Assets/Prefabs/System/SoundManager.prefab
@@ -145,6 +145,10 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: 3d534dccbc83dc7429a964801a3754eb, type: 3}
     playedTime: 0
     volume: 0.45
+  - name: EnemyFly
+    audioClip: {fileID: 8300000, guid: fb5b65e024a337e44b74e7e461a6850e, type: 3}
+    playedTime: 0
+    volume: 0.9
   - name: Ice
     audioClip: {fileID: 8300000, guid: 455a4040cbbd2fa45bcc23c3816f29a5, type: 3}
     playedTime: 0

--- a/Balance/Assets/Prefabs/System/SoundManager.prefab
+++ b/Balance/Assets/Prefabs/System/SoundManager.prefab
@@ -165,4 +165,12 @@ MonoBehaviour:
     audioClip: {fileID: 8300000, guid: 4c25222a9681e954182e09c5fe08e7a5, type: 3}
     playedTime: 0
     volume: 0.5
+  - name: Arrival
+    audioClip: {fileID: 8300000, guid: 0ef682b70ff9f9d4d961c815179df1f2, type: 3}
+    playedTime: 0
+    volume: 1
+  - name: Camera
+    audioClip: {fileID: 8300000, guid: b50a1f1cbff22854f84350c59386ec2d, type: 3}
+    playedTime: 0
+    volume: 0.95
   playableDistance: 0.2

--- a/Balance/Assets/Prefabs/System/Systems.prefab
+++ b/Balance/Assets/Prefabs/System/Systems.prefab
@@ -39,6 +39,7 @@ Transform:
   - {fileID: 4859067093144196899}
   - {fileID: 113902202471380068}
   - {fileID: 5878875953556696522}
+  - {fileID: 5903204756571620029}
   - {fileID: 7993661988360938058}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -93,7 +94,12 @@ MonoBehaviour:
   spawnInterval: 3
   circleLimit: 5
   ellipseLimit: 2
+  firstWave: 5
+  secondWave: 3
+  finalWave: 6
   phasesText: {fileID: 0}
+  FightUI: {fileID: 0}
+  waveGauge: []
   circleEnemyTest: 0
   ellipseEnemyTest: 0
 --- !u!1 &2879315829225732431
@@ -679,7 +685,7 @@ PrefabInstance:
     - target: {fileID: 6159435936500782445, guid: 197fdb1a68a11f74d99c650f3def21de,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 6159435936500782445, guid: 197fdb1a68a11f74d99c650f3def21de,
         type: 3}
@@ -818,7 +824,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   truelife:
-  - {fileID: 21300000, guid: 1d70e260c1334664685a583e681da5d5, type: 3}
+  - {fileID: 21300000, guid: 8d61d3c6d85b76a4a951c06510a6d7fa, type: 3}
   - {fileID: 21300000, guid: 314bd5fbb94cd6f4595cf2d0164b86b7, type: 3}
   - {fileID: 21300000, guid: 1cf25a0349d506f42b8d69099077c718, type: 3}
   - {fileID: 21300000, guid: d7aad8441cd25be4ba5285299c23c43e, type: 3}
@@ -826,6 +832,81 @@ MonoBehaviour:
   - 0.25
   - 0.25
   - 0.25
+--- !u!1001 &4684150060162147446
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2879315829045423266}
+    m_Modifications:
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7399610949179236820, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+        type: 3}
+      propertyPath: m_Name
+      value: FiledItemManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 876b6f511a8c8fd4f83c589664bc9d5e, type: 3}
+--- !u!4 &5903204756571620029 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1219654002456651467, guid: 876b6f511a8c8fd4f83c589664bc9d5e,
+    type: 3}
+  m_PrefabInstance: {fileID: 4684150060162147446}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &5551500619724316085
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Balance/Assets/Scenes/Main/Fight.unity
+++ b/Balance/Assets/Scenes/Main/Fight.unity
@@ -504,86 +504,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: -10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1001 &84738877
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 2178944381084319285, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_Name
-      value: SoundManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 7042175286598988680, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: bgmDatas.Array.data[1].volume
-      value: 0.2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.2801307
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 4.1851482
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -16.012907
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4d9324e406ffd9246aa7a8dadccab276, type: 3}
---- !u!4 &84738878 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7795039349650907740, guid: 4d9324e406ffd9246aa7a8dadccab276,
-    type: 3}
-  m_PrefabInstance: {fileID: 84738877}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &118475133 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 3002665149275066073, guid: ab68d39a42bb5394ba5ce0ca206df26a,
@@ -2315,7 +2235,7 @@ PrefabInstance:
     - target: {fileID: 2879315829045423266, guid: 6192ff33f6d21ff46b5ef5e5ba7d1b32,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 2879315829045423266, guid: 6192ff33f6d21ff46b5ef5e5ba7d1b32,
         type: 3}
@@ -2886,111 +2806,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6cb345f8f5da644ad0094aab516b6b, type: 3}
---- !u!1001 &684084577
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.9822059
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 3.4642708
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -5.8736825
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615185, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_Enabled
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615190, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_Name
-      value: SceneManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: _state
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: m_stage
-      value: 
-      objectReference: {fileID: 1242643358}
-    - target: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: fadeHandler
-      value: 
-      objectReference: {fileID: 1579429253}
-    - target: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: nextSceneName
-      value: GreenStage
-      objectReference: {fileID: 0}
-    - target: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-        type: 3}
-      propertyPath: searchSceneName
-      value: 
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 79d42eaef7ece164786d0a246fd0cf2a, type: 3}
---- !u!4 &684084578 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7810446846851615184, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-    type: 3}
-  m_PrefabInstance: {fileID: 684084577}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &724293856
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3125,7 +2940,7 @@ PrefabInstance:
     - target: {fileID: 5586910210129442047, guid: 25efe5b6c7a75364f812aa933ce1cc1f,
         type: 3}
       propertyPath: m_RootOrder
-      value: 14
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 5586910210129442047, guid: 25efe5b6c7a75364f812aa933ce1cc1f,
         type: 3}
@@ -3554,176 +3369,11 @@ Transform:
   m_Father: {fileID: 280832997}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: -12.79, z: 0}
---- !u!1001 &859438666
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 740474131758099480, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_Name
-      value: GameManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 8734995878564543787, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: startText
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8734995878564543787, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_nextState
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8734995878564543787, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: startButton
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 628.13367
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 258.54315
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 12.102919
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 6fe3b528cf5af6c4091f2bd4b6df0983, type: 3}
---- !u!4 &859438667 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8883353081518748972, guid: 6fe3b528cf5af6c4091f2bd4b6df0983,
-    type: 3}
-  m_PrefabInstance: {fileID: 859438666}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &887418446 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7942528409053613139, guid: 7c6cb345f8f5da644ad0094aab516b6b,
     type: 3}
   m_PrefabInstance: {fileID: 1996757106}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &899290474
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 10.492648
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -24.638857
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.6150641
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7249596636241904844, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-        type: 3}
-      propertyPath: m_Name
-      value: PlayerInputManager
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: c8f224c03cfbf7240b1e27d4ec98507b, type: 3}
---- !u!4 &899290475 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 7249596636241904842, guid: c8f224c03cfbf7240b1e27d4ec98507b,
-    type: 3}
-  m_PrefabInstance: {fileID: 899290474}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &907838533
 PrefabInstance:
@@ -4104,18 +3754,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6cb345f8f5da644ad0094aab516b6b, type: 3}
---- !u!114 &931608274 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7810446846851615191, guid: 79d42eaef7ece164786d0a246fd0cf2a,
-    type: 3}
-  m_PrefabInstance: {fileID: 684084577}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b35cc79f6a264d19a6be7f0a89df3729, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &939399379
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5300,81 +4938,6 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
   m_PVRTiledBaking: 0
---- !u!1001 &1162108971
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 4266097441926987387, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_Name
-      value: BGMManager
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -28.23088
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -113.62883
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -191.82082
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 4d2706f2fa6380b498a9a5f22f40c32a, type: 3}
---- !u!4 &1162108972 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4266097441926987389, guid: 4d2706f2fa6380b498a9a5f22f40c32a,
-    type: 3}
-  m_PrefabInstance: {fileID: 1162108971}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1167860474
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6732,43 +6295,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6cb345f8f5da644ad0094aab516b6b, type: 3}
---- !u!1 &1402511452
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1402511453}
-  m_Layer: 0
-  m_Name: 'Systems '
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1402511453
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1402511452}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1162108972}
-  - {fileID: 84738878}
-  - {fileID: 684084578}
-  - {fileID: 859438667}
-  - {fileID: 899290475}
-  - {fileID: 1843725113}
-  m_Father: {fileID: 0}
-  m_RootOrder: 9
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1419508382
 GameObject:
   m_ObjectHideFlags: 0
@@ -6833,7 +6359,7 @@ Transform:
   - {fileID: 1042376087}
   - {fileID: 437129184}
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1447955697 stripped
 Transform:
@@ -7711,7 +7237,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d78063e8b49a61d4aa25323f9c02c6a8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _transition: {fileID: 931608274}
+  _transition: {fileID: 0}
   enemys:
   - {fileID: 7359282681462766789, guid: a81489aaec5607e438714e971a569d75, type: 3}
   - {fileID: 1654121995944958511, guid: 4749abd0e06658c45bb95db8f1640ddc, type: 3}
@@ -7747,7 +7273,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 13
+  m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1648347496
 MonoBehaviour:
@@ -8567,89 +8093,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 355334329}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1843725112
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1402511453}
-    m_Modifications:
-    - target: {fileID: 1843725117, guid: 8873c4bd252db2144a710e859b466650, type: 3}
-      propertyPath: P1Spawn
-      value: 
-      objectReference: {fileID: 1000636101}
-    - target: {fileID: 1843725117, guid: 8873c4bd252db2144a710e859b466650, type: 3}
-      propertyPath: P2Spawn
-      value: 
-      objectReference: {fileID: 1000636100}
-    - target: {fileID: 2371525423099053548, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_Name
-      value: PlayerSpawnSensor
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 5
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 8873c4bd252db2144a710e859b466650, type: 3}
---- !u!4 &1843725113 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5520934948283328977, guid: 8873c4bd252db2144a710e859b466650,
-    type: 3}
-  m_PrefabInstance: {fileID: 1843725112}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1851724494
 GameObject:
   m_ObjectHideFlags: 0
@@ -8728,7 +8171,7 @@ Transform:
   - {fileID: 831110231}
   - {fileID: 1451286856}
   m_Father: {fileID: 0}
-  m_RootOrder: 12
+  m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1873076579
 PrefabInstance:

--- a/Balance/Assets/Scenes/Main/MainStage.unity
+++ b/Balance/Assets/Scenes/Main/MainStage.unity
@@ -25814,12 +25814,12 @@ PrefabInstance:
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.0000000228801
+      value: 0.00000002288009
       objectReference: {fileID: 0}
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000000008283737
+      value: -0.000000008283735
       objectReference: {fileID: 0}
     - target: {fileID: 1770166811159384395, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}

--- a/Balance/Assets/Scenes/Main/MainStage.unity
+++ b/Balance/Assets/Scenes/Main/MainStage.unity
@@ -25814,12 +25814,12 @@ PrefabInstance:
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.00000002288009
+      value: -0.0000000228801
       objectReference: {fileID: 0}
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000008283735
+      value: 0.000000008283737
       objectReference: {fileID: 0}
     - target: {fileID: 1770166811159384395, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -25909,7 +25909,7 @@ PrefabInstance:
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1296
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -25919,7 +25919,7 @@ PrefabInstance:
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 474
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -28526,7 +28526,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2087266650}
   m_LocalRotation: {x: 0.26028138, y: -0.000000016613326, z: 0.0000000044785007, w: 0.96553284}
-  m_LocalPosition: {x: 1296, y: 75, z: 444}
+  m_LocalPosition: {x: 0, y: 75, z: -30}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Balance/Assets/Scenes/Main/MainStage.unity
+++ b/Balance/Assets/Scenes/Main/MainStage.unity
@@ -4658,53 +4658,88 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 27.999996
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 27.999996
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 27.999996
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 392
+      value: 1274
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -13.535629
+      value: 107.4
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -451
+      value: -452.9
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.69968224
+      value: -0.680337
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.69968224
+      value: -0.7328994
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.10219974
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.10219974
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 73.38
+      value: -265.74
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 90
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSize.minScalar
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSpeed.minScalar
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startLifetime.minScalar
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427818, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
@@ -8229,10 +8264,40 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1854534998}
     m_Modifications:
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.maxNumParticles
+      value: 3000
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 50
+      objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
       propertyPath: m_RootOrder
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
@@ -11533,43 +11598,58 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 175
+      value: 441
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -13.535629
+      value: 66
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -238
+      value: -605.5
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.69968224
+      value: 0.707029
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.69968224
+      value: 0.707029
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.10219974
+      value: -0.010489703
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.10219974
+      value: -0.010489703
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 73.38
+      value: 91.7
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427815, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
@@ -11580,6 +11660,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSize.minScalar
+      value: 0.08
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startSpeed.minScalar
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427816, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: InitialModule.startLifetime.minScalar
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 8163886909060427818, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
         type: 3}
@@ -25714,12 +25814,12 @@ PrefabInstance:
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.00000002288009
+      value: 0.00000002288009
       objectReference: {fileID: 0}
     - target: {fileID: 632443261924561367, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000000008283735
+      value: -0.000000008283735
       objectReference: {fileID: 0}
     - target: {fileID: 1770166811159384395, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -25809,7 +25909,7 @@ PrefabInstance:
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1296
       objectReference: {fileID: 0}
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -25819,7 +25919,7 @@ PrefabInstance:
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 474
       objectReference: {fileID: 0}
     - target: {fileID: 4836122575055820819, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -25924,12 +26024,12 @@ PrefabInstance:
     - target: {fileID: 6326847176127093778, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -1e-45
+      value: 3e-45
       objectReference: {fileID: 0}
     - target: {fileID: 6326847176127093778, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 1e-45
       objectReference: {fileID: 0}
     - target: {fileID: 6326847176127093778, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -26037,17 +26137,17 @@ PrefabInstance:
     - target: {fileID: 7570074550026318021, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.26028144
+      value: 0.26028138
       objectReference: {fileID: 0}
     - target: {fileID: 7570074550026318021, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.000000016613326
       objectReference: {fileID: 0}
     - target: {fileID: 7570074550026318021, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.0000000044785007
       objectReference: {fileID: 0}
     - target: {fileID: 7947439544919898668, guid: 75434909bf02b6543a8486cdad4777e6,
         type: 3}
@@ -28425,8 +28525,8 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2087266650}
-  m_LocalRotation: {x: 0.26028144, y: 0, z: 0, w: 0.96553284}
-  m_LocalPosition: {x: 0, y: 75, z: -30}
+  m_LocalRotation: {x: 0.26028138, y: -0.000000016613326, z: 0.0000000044785007, w: 0.96553284}
+  m_LocalPosition: {x: 1296, y: 75, z: 444}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -29210,6 +29310,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1854534998}
     m_Modifications:
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.maxNumParticles
+      value: 2000
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.startSize.scalar
+      value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224897, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: InitialModule.startLifetime.scalar
+      value: 30
+      objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
       propertyPath: m_RootOrder
@@ -29217,8 +29332,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
+      propertyPath: m_LocalScale.x
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
+        type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1382.2522
+      value: 1226.5
       objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
@@ -29228,7 +29358,7 @@ PrefabInstance:
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -1615.532
+      value: -1096.4
       objectReference: {fileID: 0}
     - target: {fileID: 3968667030323224898, guid: 521707846386d7f449c349818fd6b5e3,
         type: 3}
@@ -29702,6 +29832,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Particle System_fire
+      objectReference: {fileID: 0}
+    - target: {fileID: 8163886909060427818, guid: 1f9620f3ecd09cf4daf921708fbebdbc,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1f9620f3ecd09cf4daf921708fbebdbc, type: 3}

--- a/Balance/Assets/Scenes/Main/MainStage.unity
+++ b/Balance/Assets/Scenes/Main/MainStage.unity
@@ -221,7 +221,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi
+      value: GRnezi 2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -383,6 +383,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6920535437510319360, guid: e065cfade8670364c9c0e3f0c1a0481f,
     type: 3}
   m_PrefabInstance: {fileID: 21997625}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &25854745 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1683788486}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &30717298 stripped
 Transform:
@@ -1109,6 +1115,26 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 301475840}
     m_Modifications:
+    - target: {fileID: 806874414284645109, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.0125629995
+      objectReference: {fileID: 0}
+    - target: {fileID: 806874414284645109, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.0125629995
+      objectReference: {fileID: 0}
+    - target: {fileID: 806874414284645109, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.0125629995
+      objectReference: {fileID: 0}
+    - target: {fileID: 806874414284645110, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_PropertySheet.m_Float.m_Array.Array.data[0].m_Value
+      value: 18
+      objectReference: {fileID: 0}
     - target: {fileID: 3952238111704256593, guid: 2ad507253530bd54fa68225639fa9d8e,
         type: 3}
       propertyPath: m_RootOrder
@@ -1183,6 +1209,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: antena
+      objectReference: {fileID: 0}
+    - target: {fileID: 8087446127124824117, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.6086
+      objectReference: {fileID: 0}
+    - target: {fileID: 8087446127124824117, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -1.979
+      objectReference: {fileID: 0}
+    - target: {fileID: 8226321758632712228, guid: 2ad507253530bd54fa68225639fa9d8e,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2ad507253530bd54fa68225639fa9d8e, type: 3}
@@ -1888,6 +1929,21 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1694566719}
     m_Modifications:
+    - target: {fileID: 1462936117020589158, guid: ec6df574e6bca564fae84585ba89ba1d,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3256334467780495905, guid: ec6df574e6bca564fae84585ba89ba1d,
+        type: 3}
+      propertyPath: m_PropertySheet.m_Float.m_Array.Array.data[0].m_Value
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6065098548439806195, guid: ec6df574e6bca564fae84585ba89ba1d,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 7886046444498639181, guid: ec6df574e6bca564fae84585ba89ba1d,
         type: 3}
       propertyPath: savePoint
@@ -2771,7 +2827,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi
+      value: VLnezi1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -4449,6 +4505,12 @@ Transform:
   m_Father: {fileID: 1518416148}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &295931822 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 749138462}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &299507715
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6342,6 +6404,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 422341103}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &423079328 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2132702714}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &430467772
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6944,6 +7012,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 465409191}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &469896669 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1568871362795746146, guid: 2a16126f5237822409b4481eabd8fba0,
+    type: 3}
+  m_PrefabInstance: {fileID: 1016712343}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &477480639
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7074,7 +7148,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 483876880}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -127.8, y: 0, z: -16.8}
+  m_LocalPosition: {x: -135.9, y: 20, z: -4.8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -8060,6 +8134,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7942528409053613139, guid: 07f634fe4f4e0b94490a1c57fb185119,
     type: 3}
   m_PrefabInstance: {fileID: 572070848}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &573274555 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 1659275367}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &574759691
 PrefabInstance:
@@ -9926,7 +10006,7 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea (4)
+      value: VLEncountArea 1
       objectReference: {fileID: 0}
     - target: {fileID: 1011290209381604351, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
@@ -9957,11 +10037,6 @@ PrefabInstance:
         type: 3}
       propertyPath: fightSceneName
       value: VolcanoFight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -5.84
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -10774,7 +10849,7 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea (5)
+      value: VLEncountArea 2
       objectReference: {fileID: 0}
     - target: {fileID: 1011290209381604351, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
@@ -10805,16 +10880,6 @@ PrefabInstance:
         type: 3}
       propertyPath: fightSceneName
       value: VolcanoFight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3.98
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0.07
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -10902,6 +10967,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: aff068b163d7930498e2602051196171, type: 3}
+--- !u!1 &771418739 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1139354143}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &777275172 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5452453750217734073, guid: 75434909bf02b6543a8486cdad4777e6,
@@ -15337,22 +15408,12 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea (2)
+      value: GREncountArea1
       objectReference: {fileID: 0}
     - target: {fileID: 2986039606335571844, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: fightSceneName
       value: Fight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4.02
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.17
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -18851,6 +18912,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1976272527}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1458124655 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 1607799085}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &1458533977 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 799488921305469418, guid: aff068b163d7930498e2602051196171,
@@ -19753,7 +19820,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi
+      value: GRnezi 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -19977,6 +20044,67 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f3b20963a1d3d194bb646ea2063afd2d, type: 3}
+--- !u!1 &1502151806
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1502151808}
+  - component: {fileID: 1502151807}
+  m_Layer: 0
+  m_Name: FieldItemsData
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1502151807
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502151806}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfe9e223bf7549bd95612d94ae3cf97f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fieldItems:
+  - {fileID: 498571746}
+  - {fileID: 1988505832}
+  - {fileID: 400497331}
+  - {fileID: 70872096}
+  - {fileID: 1417842048}
+  - {fileID: 1992470159}
+  - {fileID: 437257965}
+  - {fileID: 573274555}
+  - {fileID: 2087081583}
+  - {fileID: 771418739}
+  - {fileID: 423079328}
+  - {fileID: 2001271161}
+  - {fileID: 295931822}
+  - {fileID: 25854745}
+  - {fileID: 1458124655}
+  - {fileID: 469896669}
+--- !u!4 &1502151808
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1502151806}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -24.978619, y: 1.6975957, z: 89.782036}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1508328266
 GameObject:
   m_ObjectHideFlags: 0
@@ -21148,7 +21276,7 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea (1)
+      value: SNEncountArea2
       objectReference: {fileID: 0}
     - target: {fileID: 1011290209381604351, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
@@ -21179,16 +21307,6 @@ PrefabInstance:
         type: 3}
       propertyPath: fightSceneName
       value: SnowFight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.56
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 1.69
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -21981,7 +22099,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi (1)
+      value: SNnezi2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -22258,7 +22376,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi
+      value: SNnezi1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -22408,7 +22526,7 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea
+      value: SNEncountArea1
       objectReference: {fileID: 0}
     - target: {fileID: 1011290209381604351, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
@@ -22439,16 +22557,6 @@ PrefabInstance:
         type: 3}
       propertyPath: fightSceneName
       value: SnowFight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.59
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 3.26
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -23437,6 +23545,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1476448651}
     m_Modifications:
+    - target: {fileID: 906908757167854976, guid: a173ce74b485b8e40a3b22bd25a9b831,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5768352706661252381, guid: a173ce74b485b8e40a3b22bd25a9b831,
         type: 3}
       propertyPath: m_Name
@@ -23511,6 +23624,26 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8470884667241361233, guid: a173ce74b485b8e40a3b22bd25a9b831,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.05961149
+      objectReference: {fileID: 0}
+    - target: {fileID: 8470884667241361233, guid: a173ce74b485b8e40a3b22bd25a9b831,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.05961149
+      objectReference: {fileID: 0}
+    - target: {fileID: 8470884667241361233, guid: a173ce74b485b8e40a3b22bd25a9b831,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.05961149
+      objectReference: {fileID: 0}
+    - target: {fileID: 8470884667241361234, guid: a173ce74b485b8e40a3b22bd25a9b831,
+        type: 3}
+      propertyPath: m_PropertySheet.m_Float.m_Array.Array.data[0].m_Value
+      value: 17
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a173ce74b485b8e40a3b22bd25a9b831, type: 3}
@@ -26787,7 +26920,7 @@ PrefabInstance:
     - target: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
         type: 3}
       propertyPath: m_Name
-      value: nezi
+      value: VLnezi2
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 071abfbb66a30c146b36eb44509138ec, type: 3}
@@ -27215,6 +27348,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1986302227}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1988505832 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 1494873604}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1990100544
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27310,6 +27449,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1990100544}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1992470159 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2029693044007660868, guid: 071abfbb66a30c146b36eb44509138ec,
+    type: 3}
+  m_PrefabInstance: {fileID: 1969411439}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1994557941 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7841025190085204289, guid: 6192ff33f6d21ff46b5ef5e5ba7d1b32,
@@ -27396,6 +27541,12 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6920535437510319360, guid: e065cfade8670364c9c0e3f0c1a0481f,
     type: 3}
   m_PrefabInstance: {fileID: 1999181311}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2001271161 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
+    type: 3}
+  m_PrefabInstance: {fileID: 703423760}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2002476644
 PrefabInstance:
@@ -28858,7 +29009,7 @@ PrefabInstance:
     - target: {fileID: 1011290209381604350, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
       propertyPath: m_Name
-      value: EncountArea (3)
+      value: GREncountArea2
       objectReference: {fileID: 0}
     - target: {fileID: 1011290209381604351, guid: f4ddc53c5ebb8024fba74878725f446b,
         type: 3}
@@ -28889,16 +29040,6 @@ PrefabInstance:
         type: 3}
       propertyPath: fightSceneName
       value: Fight
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -5.6
-      objectReference: {fileID: 0}
-    - target: {fileID: 7140707032865629863, guid: f4ddc53c5ebb8024fba74878725f446b,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.73
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f4ddc53c5ebb8024fba74878725f446b, type: 3}
@@ -29431,17 +29572,17 @@ PrefabInstance:
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 69.11806
+      value: 230.75754
       objectReference: {fileID: 0}
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 29.608
+      value: 346.86072
       objectReference: {fileID: 0}
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -27
+      value: -17.1
       objectReference: {fileID: 0}
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
@@ -29451,7 +29592,7 @@ PrefabInstance:
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -187.2
+      value: -121.4
       objectReference: {fileID: 0}
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
@@ -29486,6 +29627,11 @@ PrefabInstance:
     - target: {fileID: 8108924822746846865, guid: b2b3423cb42e64b43999cf304484ddef,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8108924822746846867, guid: b2b3423cb42e64b43999cf304484ddef,
+        type: 3}
+      propertyPath: m_Enabled
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
+++ b/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
@@ -29,7 +29,7 @@ public class EncountAnimation : MonoBehaviour
     {
         if (time >= waitTime)
         {
-            Destroy(gameObject);
+          //  Destroy(gameObject);
             //anim.SetBool("AbleMove", true);
         }
         else
@@ -48,7 +48,7 @@ public class EncountAnimation : MonoBehaviour
     {
         if(reflected)
         {
-            Destroy(gameObject);
+          //  Destroy(gameObject);
         }
     }
 }

--- a/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
+++ b/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
@@ -29,7 +29,7 @@ public class EncountAnimation : MonoBehaviour
     {
         if (time >= waitTime)
         {
-          //  Destroy(gameObject);
+            Destroy(gameObject);
             //anim.SetBool("AbleMove", true);
         }
         else
@@ -48,7 +48,7 @@ public class EncountAnimation : MonoBehaviour
     {
         if(reflected)
         {
-          //  Destroy(gameObject);
+            Destroy(gameObject);
         }
     }
 }

--- a/Balance/Assets/Scripts/Enemy/EnemyManager.cs
+++ b/Balance/Assets/Scripts/Enemy/EnemyManager.cs
@@ -370,7 +370,7 @@ public class EnemyManager : MonoBehaviour
         int enemySpawnPos;
 
         GameObject newEnemy = Instantiate(enemys[0]);
-
+        SoundManager.instance.Play("EnemyFly");
         enemySpawnPos = Random.Range(0, enemySpawnPoints.Length);
         newEnemy.transform.position = enemySpawnPoints[enemySpawnPos].transform.position;
     }
@@ -380,7 +380,7 @@ public class EnemyManager : MonoBehaviour
         int enemySpawnPos;
 
         GameObject newEnemy = Instantiate(enemys[1]);
-
+        SoundManager.instance.Play("EnemyFly");
         enemySpawnPos = Random.Range(0, enemySpawnPoints.Length);
         newEnemy.transform.position = enemySpawnPoints[enemySpawnPos].transform.position;
     }

--- a/Balance/Assets/Scripts/Enemy/EnemySphere.cs
+++ b/Balance/Assets/Scripts/Enemy/EnemySphere.cs
@@ -136,7 +136,7 @@ public class EnemySphere : MonoBehaviour
                 SoundManager.instance.Play("Explosion");
             }
 
-            if (explosionTime > 8f)
+            if (explosionTime > 7.86f)
             {
                 enemymanager.DestroyEnemy();
                 Destroy(this.gameObject);

--- a/Balance/Assets/Scripts/Gimmick/Coin.cs
+++ b/Balance/Assets/Scripts/Gimmick/Coin.cs
@@ -50,7 +50,6 @@ public class Coin : MonoBehaviour
         if(count)
         {
             coinmanager.Count();
-            SoundManager.instance.Play("GetCoin");
             Destroy(gameObject);
         }
     }

--- a/Balance/Assets/Scripts/Gimmick/CoinManager.cs
+++ b/Balance/Assets/Scripts/Gimmick/CoinManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using UnityEngine;
@@ -25,8 +26,9 @@ public class CoinManager : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        InstanceParts();
-    }
+        if (parts != null)
+         InstanceParts();
+    }   
 
     private void Set()
     {
@@ -41,6 +43,9 @@ public class CoinManager : MonoBehaviour
         if (countCoin < coins.Length)
         {
             CoinSpawn();
+            if (countCoin > 1)
+             SoundManager.instance.Play("GetCoin");
+            
         }
     }
 
@@ -52,9 +57,10 @@ public class CoinManager : MonoBehaviour
 
     private void InstanceParts()
     {
-        if (countCoin >= coins.Length)
+        if (countCoin >= coins.Length && parts.activeSelf == false)
         {
             parts.SetActive(true);
+            SoundManager.instance.Play("Arrival");
         }
     }
 }

--- a/Balance/Assets/Scripts/Gimmick/GateManager.cs
+++ b/Balance/Assets/Scripts/Gimmick/GateManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -27,6 +28,7 @@ public class GateManager : MonoBehaviour
         if(GateNumber==clearNum)
         {
             parts.SetActive(true);
+            SoundManager.instance.Play("Arrival");
         }
 
     }

--- a/Balance/Assets/Scripts/Gimmick/PartsArrival.cs
+++ b/Balance/Assets/Scripts/Gimmick/PartsArrival.cs
@@ -37,7 +37,7 @@ public class PartsArrival : MonoBehaviour
         m_leaveTime = 0.0f;
         isStay = false;
     }
-
+    
     private void Update()
     {
         CheckMove();
@@ -50,8 +50,10 @@ public class PartsArrival : MonoBehaviour
                 gauge.SetActive(true);
                 TimeGauge();
                 m_stayTime += Time.deltaTime; // 滞在時間を減少させる
+             
                 if (m_stayTime >= needStayTime)
                 {
+                    SoundManager.instance.Play("Arrival");
                     part.SetActive(true); // サブパーツを表示
                     Destroy(gameObject); // エリアを削除
                     Destroy(gauge);
@@ -101,13 +103,19 @@ public class PartsArrival : MonoBehaviour
         }
     }
 
+    private int beforeFrameTime;
     private void TimeGauge()
     {
         //double displaytext = Math.Floor(m_stayTime);
         int displaytext = (int)m_stayTime;
+        if (beforeFrameTime != displaytext)
+        {
+            SoundManager.instance.Play("Connected");
+        }
         gaugeText.text = displaytext.ToString();
 
         gauge.GetComponent<Image>().fillAmount = m_stayTime - displaytext;
+        beforeFrameTime = displaytext;
     }
 
     private void OnTriggerEnter(Collider other)

--- a/Balance/Assets/Scripts/Player/PlayerController.cs
+++ b/Balance/Assets/Scripts/Player/PlayerController.cs
@@ -313,6 +313,7 @@ public class PlayerController : MonoBehaviour
                 if (cmswitch.IsPlayerInContact())
                 {
                     cmswitch.SetSwitchPressed(true); // スイッチを押す
+                    SoundManager.instance.Play("Camera");
                     animator.SetTrigger("toPush");
                 }
             }

--- a/Balance/Assets/Scripts/System/FieldItems.meta
+++ b/Balance/Assets/Scripts/System/FieldItems.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fbfb3e7327b4492b88ee3aca1404ef1c
+timeCreated: 1736759382

--- a/Balance/Assets/Scripts/System/FieldItems/FieldItemData.cs
+++ b/Balance/Assets/Scripts/System/FieldItems/FieldItemData.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+
+namespace System
+{
+    public class FieldItemData : MonoBehaviour
+    {
+        public GameObject[] fieldItems;
+
+        private void Awake()
+        {
+            if (GameManager.instance != null)
+                GameManager.instance.OnInitGame += Init;
+            
+            if (GameManager.instance.isConnected == false)  
+              GameManager.instance.InitGame(false);
+        }
+
+        private void OnDisable()
+        {
+            if (GameManager.instance != null)
+                GameManager.instance.OnInitGame -= Init;
+        }
+
+        private void Init()
+        {
+            Debug.Log("Item acquisition status has been reset");
+            FieldItemsManager.instance.Initialize(fieldItems);
+        }
+    }
+}

--- a/Balance/Assets/Scripts/System/FieldItems/FieldItemData.cs.meta
+++ b/Balance/Assets/Scripts/System/FieldItems/FieldItemData.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cfe9e223bf7549bd95612d94ae3cf97f
+timeCreated: 1736759791

--- a/Balance/Assets/Scripts/System/FieldItems/FieldItemsManager.cs
+++ b/Balance/Assets/Scripts/System/FieldItems/FieldItemsManager.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections;
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace System
+{
+    public class FieldItemsManager : MonoBehaviour
+    {
+        public static FieldItemsManager instance = null;
+        
+        private Dictionary<string, bool> list = new();
+
+        [HideInInspector]
+        public bool[] acquired;
+
+        private void Awake()
+        {
+            if (instance == null)
+            {
+                transform.parent = null;
+                instance = this;
+                DontDestroyOnLoad(this.gameObject);
+            }
+            else
+            {
+                // 他のシーン遷移した時の二重生成防ぐ
+                Destroy(this.gameObject);
+            }
+        }
+
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.X))
+            {
+                foreach (var pair in list)
+                {
+                    Debug.Log($"Key: {pair.Key}, Value: {pair.Value}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// ゲーム開始時のみ呼び出したい
+        /// </summary>
+        /// <param name="items">フィールドアイテムのデータ</param>
+        public void Initialize(GameObject[] items)
+        {
+            acquired = new bool[items.Length];
+            list = new();
+
+            for (int i = 0; i < items.Length; i++)
+            {
+                list.Add(items[i].name, acquired[i]);
+            }
+       
+        }
+
+        /// <summary>
+        /// 自機が触れてパーツなどのItemを取得した時呼び出す Destroy
+        /// </summary>
+        /// <param name="name">gameObject.name</param>
+        public void GetItem(string name)
+        {
+            // TryGetValueはコピーだから直接更新できない
+            if (list.ContainsKey(name))
+            {
+                list[name] = true; // 直接更新
+            }
+            else
+            {
+                Debug.LogAssertion("The item does not exist");
+            }
+        }
+
+        public bool GetIsAcquired(string name)
+        {
+            if (instance.list.TryGetValue(name, out bool acquired))
+            {
+                return acquired;
+            }
+            
+            Debug.LogAssertion("The item does not exist");
+            return false;
+        }
+        
+    }
+}

--- a/Balance/Assets/Scripts/System/FieldItems/FieldItemsManager.cs.meta
+++ b/Balance/Assets/Scripts/System/FieldItems/FieldItemsManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8b8a1a1cf5704ceaba078b3d3973abfd
+timeCreated: 1736758450

--- a/Balance/Assets/Scripts/System/GameManager.cs
+++ b/Balance/Assets/Scripts/System/GameManager.cs
@@ -54,7 +54,10 @@ public class GameManager : MonoBehaviour
             Destroy(this.gameObject);
         }
 
-        // デバッグ用
+        // ここで体力初期化しないとMainStageから開始した時UIバグる
+        InitLifeAndTime();
+        
+        // デバッグ用 戦闘からでもプレイヤーが動く
         if (CurrentState == GameState.EnemyBattle)
             InitGame(true);
     }
@@ -64,15 +67,13 @@ public class GameManager : MonoBehaviour
     /// <param name="isContinue"> true : セーブポイントからスタート </param>
     public void InitGame(bool isContinue)
     {
-        m_life = initialLife;
-        m_mainParts = 0;
-        m_subParts = 0;
+        InitLifeAndTime();
         isPlayerSpawn = new bool [2];
-        method = new ThrowawayMethod();
-        count = 0;
         isConnected = false;
         playerInstances = new GameObject[2];
-        _timeArray = new int[4] { 0, 0, 0, 0 };
+        m_mainParts = 0;
+        m_subParts = 0;
+        count = 0;
 
         if (isContinue == false)
         {
@@ -80,6 +81,15 @@ public class GameManager : MonoBehaviour
             isSkip = false;
         }
         // SavePointの初期化はどうせ上書きされるから必要ない
+    }
+
+    /// <summary>
+    /// いつ初期化してもエラーが起きない変数のみ
+    /// </summary>
+    public void InitLifeAndTime()
+    {
+        _timeArray = new int[4] { 0, 0, 0, 0 };
+        m_life = initialLife;
     }
     
     public IEnumerator Restart()
@@ -99,6 +109,7 @@ public class GameManager : MonoBehaviour
         if (beforeLoading)
         {
             PlayerDestroy();
+            InitLifeAndTime();
         }
         else
         {
@@ -135,8 +146,6 @@ public class GameManager : MonoBehaviour
        Application.Quit();
 #endif
     }
-
-    private ThrowawayMethod method = new ThrowawayMethod();
   
     private void Update()
     {

--- a/Balance/Assets/Scripts/System/GameManager.cs
+++ b/Balance/Assets/Scripts/System/GameManager.cs
@@ -20,6 +20,8 @@ public class GameManager : MonoBehaviour
 {
     public static GameManager instance = null;
     
+    public event Action OnInitGame;
+    
     [SerializeField] private GameState m_currentState;
     [SerializeField] private RescueState currentRescue;
 
@@ -44,16 +46,23 @@ public class GameManager : MonoBehaviour
             transform.parent = null;
             instance = this;
             DontDestroyOnLoad(this.gameObject);
+            m_beforeState = m_currentState;
         }
         else
         {
             // 他のシーン遷移した時の二重生成防ぐ
             Destroy(this.gameObject);
         }
-        
-        InitGame();
+
+        // デバッグ用
+        if (CurrentState == GameState.EnemyBattle)
+            InitGame(true);
     }
-    public void InitGame()
+    /// <summary>
+    /// ゲームの初期化 セーブポイントからスタートなのか、最初からなのかによって処理を切り替え
+    /// </summary>
+    /// <param name="isContinue"> true : セーブポイントからスタート </param>
+    public void InitGame(bool isContinue)
     {
         m_life = initialLife;
         m_mainParts = 0;
@@ -64,16 +73,22 @@ public class GameManager : MonoBehaviour
         isConnected = false;
         playerInstances = new GameObject[2];
         _timeArray = new int[4] { 0, 0, 0, 0 };
-        isSkip = false;
+
+        if (isContinue == false)
+        {
+            OnInitGame?.Invoke();   // フィールドアイテムの取得状況を初期化する関数を呼び出す
+            isSkip = false;
+        }
         // SavePointの初期化はどうせ上書きされるから必要ない
     }
     
-    public void Restart()
+    public IEnumerator Restart()
     {
         _sceneManager.FadeStart("MainStage");
         m_currentState = GameState.Search;
         PlayerDestroy();
-        InitGame();
+        yield return new WaitForSeconds(1.7f);
+        InitGame(false);
     }
 
     /// <summary>
@@ -84,11 +99,10 @@ public class GameManager : MonoBehaviour
         if (beforeLoading)
         {
             PlayerDestroy();
-            InitGame();
-            isSkip = true;
         }
         else
         {
+            InitGame(true);
             SetAircraftPos();
             AircraftMoveSwitch(true);
         }
@@ -138,7 +152,7 @@ public class GameManager : MonoBehaviour
 
         if (Input.GetKeyDown(KeyCode.R))
         {
-            method.RunOnce(Restart);
+            StartCoroutine(Restart());
         }
         
         if (Input.GetKeyDown(KeyCode.K))

--- a/Balance/Assets/Scripts/System/SavePoint.cs
+++ b/Balance/Assets/Scripts/System/SavePoint.cs
@@ -5,14 +5,34 @@ namespace System
     public class SavePoint : MonoBehaviour
     {
         [SerializeField] private GameObject savePoint;
+        private void Start()
+        {
+            // すでにこのアイテムを取得済みなら消す
+            if (FieldItemsManager.instance.GetIsAcquired(gameObject.name) == true)
+            {
+                Destroy(gameObject);
+            }
+        }
         private void Save()
         {
             GameManager.instance.SaveAircraftPos(savePoint.transform.position);
+          
         }
 
+        private void GetItem()
+        {
+            if (FieldItemsManager.instance.GetIsAcquired(gameObject.name) == false)
+            {
+                FieldItemsManager.instance.GetItem(gameObject.name);
+            }
+        }
+
+        private ThrowawayMethod method1 = new ThrowawayMethod();
+        private ThrowawayMethod method2 = new ThrowawayMethod();
         private void OnTriggerEnter(Collider other)
         {
-            Save();
+            method1.RunOnce(Save); 
+            method2.RunOnce(GetItem);
         }
     }
 }

--- a/Balance/Assets/Scripts/System/SceneTransitionHandler.cs
+++ b/Balance/Assets/Scripts/System/SceneTransitionHandler.cs
@@ -58,10 +58,12 @@ namespace System
             Debug.Log("BeforeScene = " + m_beforeSceneName);
             if (scene.name == "Fight" || scene.name == "MainStage" || scene.name == "SnowFight" || scene.name == "VolcanoFight")
             {
-                GameManager.instance.PlayerUnLock();
-                GameManager.instance.RespawnPlayer(false);
-                GameManager.instance.SetPlayerPos();
-                Debug.Log("リスポーン");
+                if (GameManager.instance.isConnected)
+                {
+                    GameManager.instance.PlayerUnLock();
+                    GameManager.instance.RespawnPlayer(false);
+                    GameManager.instance.SetPlayerPos();
+                }
             }
             
             // 戦闘->探索
@@ -69,12 +71,7 @@ namespace System
             {
                 if ( scene.name == "MainStage")
                 {
-                    //GameManager.instance.RespawnPlayer(false);
                     GameManager.instance.Back2Search();
-                    /*if (GameManager.instance.CurrentState == GameState.Restart)
-                    {
-                        GameManager.instance.CurrentState = GameState.Search;
-                    }*/
                 }
             }
 
@@ -82,7 +79,7 @@ namespace System
             {
                 if (scene.name == "MainStage")
                 {
-                    GameManager.instance.InitGame();
+                    GameManager.instance.InitGame(false);
                 }
             }
       

--- a/Balance/Assets/Scripts/System/StageManager.cs
+++ b/Balance/Assets/Scripts/System/StageManager.cs
@@ -44,8 +44,8 @@ public class StageManager : MonoBehaviour
         GameManager.instance.SaveAircraftInstance(gameObject);
 
         // スタート時の位置を設定
-      //  if (GameManager.instance.CurrentState == GameState.Search)
-           // transform.position = new Vector3(transform.position.x, 50f, transform.position.z);
+        if (GameManager.instance.CurrentState == GameState.Search)
+            transform.position = new Vector3(transform.position.x, 50f, transform.position.z);
     }
 
     private void Update()

--- a/Balance/Assets/Scripts/System/UISystem/BlinkingSystem.cs
+++ b/Balance/Assets/Scripts/System/UISystem/BlinkingSystem.cs
@@ -34,10 +34,11 @@ namespace System
             {
                 for (int j = 0; j < 4; j++)
                 {
-                    lifeImage[i + j].sprite = truelife[j];
+                    if (i + j < GameManager.instance.Life) // 体力状況を加味
+                    {
+                        lifeImage[i + j].sprite = truelife[j];
+                    }
                 }
-
-              //  i += 3;
             }
         }
 

--- a/Balance/Assets/Scripts/System/UISystem/TimeCalc.cs
+++ b/Balance/Assets/Scripts/System/UISystem/TimeCalc.cs
@@ -20,6 +20,12 @@ namespace System
             timeArray = new int[4] { 0, 0, 0, 0 };
             time = 0f;
             isStopTimer = true;
+         
+        }
+
+        private void Start()
+        {
+            // GameMangerのAwakeが最優先だからここでInitializeしないとNullエラー出る
             InitializeTimer();
         }
 

--- a/Balance/Assets/Scripts/Test/ChangeScene.cs
+++ b/Balance/Assets/Scripts/Test/ChangeScene.cs
@@ -9,7 +9,7 @@ public class ChangeScene : MonoBehaviour
 {
     public void ToGreenScene()
     {
-        GameManager.instance.Restart();
+        StartCoroutine(GameManager.instance.Restart());
         SoundManager.instance.Play("CursorDecision");
     }
 

--- a/Balance/Assets/Sounds/SE/System/カメラ切り替え.wav
+++ b/Balance/Assets/Sounds/SE/System/カメラ切り替え.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:547502631b3789f200c64cbd048d290d23fbd85ed5b5f6cab270218b59c5d82d
+size 203118

--- a/Balance/Assets/Sounds/SE/System/カメラ切り替え.wav.meta
+++ b/Balance/Assets/Sounds/SE/System/カメラ切り替え.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: b50a1f1cbff22854f84350c59386ec2d
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Balance/Assets/Sounds/SE/System/パーツ出現.wav
+++ b/Balance/Assets/Sounds/SE/System/パーツ出現.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14b99a7e308fe14c179f8398f21b21ce90f606798427de32fdb9579be1c71812
+size 307758

--- a/Balance/Assets/Sounds/SE/System/パーツ出現.wav.meta
+++ b/Balance/Assets/Sounds/SE/System/パーツ出現.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 0ef682b70ff9f9d4d961c815179df1f2
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Balance/Assets/Sounds/SE/敵が飛ぶ音.wav
+++ b/Balance/Assets/Sounds/SE/敵が飛ぶ音.wav
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48d0457595acb0001025e05f331462667e5e708d6d090d0f03f90b09bc1b4f61
+size 496698

--- a/Balance/Assets/Sounds/SE/敵が飛ぶ音.wav.meta
+++ b/Balance/Assets/Sounds/SE/敵が飛ぶ音.wav.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: fb5b65e024a337e44b74e7e461a6850e
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Balance/ProjectSettings/EditorBuildSettings.asset
+++ b/Balance/ProjectSettings/EditorBuildSettings.asset
@@ -5,12 +5,9 @@ EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Scenes:
-  - enabled: 0
+  - enabled: 1
     path: Assets/Scenes/Main/Start.unity
     guid: 919b49bc8ad6e53419ee35c35359f01a
-  - enabled: 0
-    path: Assets/Scenes/Main/GreenStage.unity
-    guid: 7ba514c678d39254db905a7c2bc2e748
   - enabled: 1
     path: Assets/Scenes/Main/MainStage.unity
     guid: d6e324ee2eb3b82448013ebf28cb0c30


### PR DESCRIPTION
## やった事
<!-- このプルリクエストにて何をしたのか？ -->
- パーツやエンカウントの進行情報保持と反映
- ストップギミックの音追加、調整
- メインパーツにきらきらつけた
- メインパーツ出現時に音追加
- カメラ切り替えた時の音追加
- 爆弾敵の爆発エフェクト消すタイミングをちょうど良く
- 敵が降ってくる音追加
- 体力の画像を一部置き換え
- 戦闘から戻った時の体力表示バグ修正
- セーブポイントから再スタートした時の体力表示バグ修正
- コインギミックのコード最適化、最後のねじ出現時の音追加
- 雪エリア、火山エリアのパーティクルが小さかったらエリア全体に降るよう調整
- StageManagerいじってリスポーンしても自機の高さが一定に
- デバッグ用で戦闘からゲーム開始してもプレイヤーが動くように

## 備考
<!-- レビュワーがレビューするにあたっての補足情報など -->
- これからセリフ表示やる