### PR TITLE
シーン遷移時とエンカウントアニメーション中プレイヤー動かせないように

### DIFF
--- a/Balance/Assets/Prefabs/System/Systems.prefab
+++ b/Balance/Assets/Prefabs/System/Systems.prefab
@@ -541,7 +541,7 @@ PrefabInstance:
     - target: {fileID: 7810446846851615185, guid: 79d42eaef7ece164786d0a246fd0cf2a,
         type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7810446846851615190, guid: 79d42eaef7ece164786d0a246fd0cf2a,
         type: 3}

--- a/Balance/Assets/Scenes/Main/Opning.unity
+++ b/Balance/Assets/Scenes/Main/Opning.unity
@@ -829,6 +829,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5445180134286841149, guid: 6192ff33f6d21ff46b5ef5e5ba7d1b32,
         type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5445180134286841149, guid: 6192ff33f6d21ff46b5ef5e5ba7d1b32,
+        type: 3}
       propertyPath: m_videoPlayer
       value: 
       objectReference: {fileID: 1679625133}

--- a/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
+++ b/Balance/Assets/Scripts/Enemy/EncountAnimation.cs
@@ -14,7 +14,7 @@ public class EncountAnimation : MonoBehaviour
     private int waitTime;
     private bool reflected;
 
-    // Start is called before the first frame update
+  
     void Start()
     {
         time = 0f;
@@ -24,12 +24,13 @@ public class EncountAnimation : MonoBehaviour
         reflected = false;
     }
 
-    // Update is called once per frame
+    private ThrowawayMethod m_method = new ThrowawayMethod();
     void Update()
     {
         if (time >= waitTime)
         {
             Destroy(gameObject);
+            m_method.RunOnce(GameManager.instance.PlayerUnLock); 
             //anim.SetBool("AbleMove", true);
         }
         else

--- a/Balance/Assets/Scripts/Player/PlayerController.cs
+++ b/Balance/Assets/Scripts/Player/PlayerController.cs
@@ -593,7 +593,7 @@ public class PlayerController : MonoBehaviour
     }
 
     private const float controlPower = 0.1f;
-    void MoveCalc()
+    private void MoveCalc()
     {
 
         //プレイヤーの正面を基準に移動方向を決めるとぐるぐる回り続ける
@@ -695,6 +695,11 @@ public class PlayerController : MonoBehaviour
             }
         }
         return false;
+    }
+
+    public void ForceStop()
+    {
+        m_inputMove = Vector2.zero;
     }
 
     private bool is1P;

--- a/Balance/Assets/Scripts/Player/PlayerManager.cs
+++ b/Balance/Assets/Scripts/Player/PlayerManager.cs
@@ -1,4 +1,5 @@
 using Dialogue;
+using JetBrains.Annotations;
 using System;
 using System.Collections;
 using Unity.Mathematics;
@@ -59,6 +60,7 @@ public class PlayerManager : MonoBehaviour
         GameManager.instance.SavePlayerInstance(gameObject);
 
         m_RB = GetComponent<Rigidbody>();
+        _playerController = GetComponent<PlayerController>();
 
         if (GameManager.instance.isConnected == false && GameManager.instance.CurrentState == GameState.Search)
         {
@@ -223,7 +225,7 @@ public class PlayerManager : MonoBehaviour
             return;
         }
 
-        _playerController = GetComponent<PlayerController>();
+        
         _playerController.enabled = false;
         GameManager.instance.IsRescue = false;
         rescState = RescueState.None;
@@ -244,13 +246,18 @@ public class PlayerManager : MonoBehaviour
 
     public void LockPos()
     {
+        _playerController.ForceStop();
         GameManager.instance.ResetRBVelocity(m_RB);
         m_RB.isKinematic = true;
-      //  Debug.Log("call Lock");
+        Debug.Log("call Lock");
         //GameManager.instance.ResetRBVelocity(m_RB);
     }
  
-    public void UnLockPos() => m_RB.isKinematic = false;
+    public void UnLockPos()
+    {
+        m_RB.isKinematic = false; 
+        Debug.Log("Call UnLock");
+    } 
     
     public bool IsLockPos() => m_RB.isKinematic;
 }

--- a/Balance/Assets/Scripts/System/FadeSystem/SceneTransitionHandler.cs
+++ b/Balance/Assets/Scripts/System/FadeSystem/SceneTransitionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Dialogue;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -61,10 +62,14 @@ namespace System
             {
                 if (GameManager.instance.isConnected)
                 {
-                    GameManager.instance.PlayerUnLock();
+                  //  GameManager.instance.PlayerUnLock(); プレイヤーのアンロックは開始アニメーション流し終わってから
                     GameManager.instance.RespawnPlayer(false);
                     GameManager.instance.SetPlayerPos();
-
+                    if (scene.name == "Fight")
+                    {
+                        // エンカウントアニメーション再生中は動けないように
+                        StartCoroutine(DelayLock());
+                    }
                     StartCoroutine(DisplayDialogue.dialogue.DelayEnqueue("Battle01", 4.5f));
                     StartCoroutine(DisplayDialogue.dialogue.DelayEnqueue("Battle02", 4.5f));
                 }
@@ -106,6 +111,16 @@ namespace System
         private void OnActiveSceneChanged(Scene oldScene, Scene newScene)
         {
             Debug.Log($"アクティブシーンが変更されました : {oldScene.name} -> {newScene.name}");
+        }
+
+        /// <summary>
+        /// jointManagerで時間差でロック解除されちゃうから、ロック自体に遅延をかけて解決
+        /// </summary>
+        /// <returns></returns>
+        private IEnumerator DelayLock()
+        {
+            yield return new WaitForSeconds(0.2f);
+            GameManager.instance.PlayerLock();
         }
     }
 }

--- a/Balance/Assets/Scripts/System/UISystem/ConnectionScreen.cs
+++ b/Balance/Assets/Scripts/System/UISystem/ConnectionScreen.cs
@@ -32,9 +32,7 @@ public class ConnectionScreen : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        if (DebugDiaogue)
-            GameManager.instance.isSkip = true;
-        
+       
         m_1PImage.SetActive(false);
         m_2PImage.SetActive(false);
         once = false;
@@ -102,7 +100,9 @@ public class ConnectionScreen : MonoBehaviour
         
         connectionScreen.SetActive(false);
         GameManager.instance.PlayerLock();
-
+        
+        if (DebugDiaogue) GameManager.instance.isSkip = true;
+        
         if (GameManager.instance.isSkip == false)
         {
             OPDialogue();
@@ -120,6 +120,7 @@ public class ConnectionScreen : MonoBehaviour
         GameManager.instance.AircraftMoveSwitch(true);
         UISystems.StartTimer();
 
+       
         if (GameManager.instance.isSkip == false)
         {
             yield return new WaitForSeconds(2f);


### PR DESCRIPTION
## やった事
<!-- このプルリクエストにて何をしたのか？ -->
- シーン遷移時とエンカウントアニメーション中プレイヤーが動けてしまうバグ修正

### Related Issue
<!-- 番号を#のあと指定するとissue閉じれるよ -->
close #~~

### 動作確認
<!--
どの環境でどんな動作チェックをしたか
動作確認をした事についてスクショなどがあるとわかりやすくて良い)
-->
- 大体確認したけど少し心配

### レビューしてほしいこと
[ ]


## 備考
<!-- レビュワーがレビューするにあたっての補足情報など -->
-